### PR TITLE
Mxfp4 memory leak fixes

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -350,6 +350,7 @@ class QuarkW4A4MXFp4MoEMethod(QuarkMoEMethod):
             w13_quantizer(layer.w13_weight.data).to(float_dtype),
             requires_grad=False,
         )
+        layer.w13_weight_scale = None
 
         w2_quantizer = realquantizer.get_real_quantizer(
             qspec=weight_quant_spec,
@@ -366,6 +367,10 @@ class QuarkW4A4MXFp4MoEMethod(QuarkMoEMethod):
             w2_quantizer(layer.w2_weight.data).to(float_dtype),
             requires_grad=False,
         )
+        layer.w2_weight_scale = None
+
+        # This call is necessary to release the scales memory.
+        torch.cuda.empty_cache()
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -10,7 +10,7 @@ from vllm.model_executor.parameter import (GroupQuantScaleParameter,
                                            PackedvLLMParameter)
 from vllm.platforms import current_platform
 
-from vllm.model_executor.layers.quantization.utils.mxfp4_utils import OCP_MX_BLOCK_SIZE
+from vllm.model_executor.layers.quantization.utils.mxfp4_utils import OCP_MX_BLOCK_SIZE, per_token_group_quant_mxfp4
 
 __all__ = ["QuarkW4A4MXFP4"]
 
@@ -37,17 +37,6 @@ class QuarkW4A4MXFP4(QuarkScheme):
                     "The package `amd-quark` is required to use AMD Quark "
                     "MX-FP4 models. Please install it with `pip install "
                     "amd-quark`.") from err
-
-            input_quant_spec = QuantizationSpec.from_dict(
-                self.input_quant_spec)
-
-            self.input_quantizer = realquantizer.get_real_quantizer(
-                qspec=input_quant_spec,
-                quantizer=None,
-                real_quantized=False,
-                float_dtype=self.out_dtype,
-            )
-
 
     @classmethod
     def get_min_capability(cls) -> int:
@@ -89,6 +78,10 @@ class QuarkW4A4MXFP4(QuarkScheme):
                 weight_quantizer(layer.weight.data).to(self.out_dtype),
                 requires_grad=False,
             )
+            layer.weight_scale = None
+            
+            # This call is necessary to release the scales memory.
+            torch.cuda.empty_cache()
 
     def create_weights(self, layer: torch.nn.Module,
                        output_partition_sizes: List[int],
@@ -132,7 +125,7 @@ class QuarkW4A4MXFP4(QuarkScheme):
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
 
         if self.emulate:
-            qdq_x = self.input_quantizer(x)
+            qdq_x, _ = per_token_group_quant_mxfp4(x, 32)
             return F.linear(qdq_x, layer.weight, bias)
         else:
             raise NotImplementedError()

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -20,7 +20,8 @@ def per_token_group_quant_mxfp4(x: torch.Tensor, block_k: int):
     # TODO: there are other rounding strategies supported in quark and in the config.json that we do not check for here! 
     scale = even_round(amax, "fp4")
 
-    x_qdq = scaled_fake_quantize(
+    # Apply dequantize(quantize(x)).
+    x = scaled_fake_quantize(
         "fp4",
         x,
         scale.to(x.device),
@@ -34,4 +35,4 @@ def per_token_group_quant_mxfp4(x: torch.Tensor, block_k: int):
         'None',  # must be a string in quark hw_emulation_interface.py, why?
     )
 
-    return x_qdq, scale
+    return x, scale


### PR DESCRIPTION
Quark real quantizer has memory leaks, even when using static shapes:
* `self.observer` is reinstantiated at each forward => for some reason pytorch then sometimes reallocates new scale buffers.
* `self.amax` is stateful, although quantization is dynamic => for some reason pytorch does not always reuse the previous `amax` buffers.

https://discuss.pytorch.org/t/how-to-debug-causes-of-gpu-memory-leaks/6741